### PR TITLE
Fix #7: Some repositories not cloned

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@ A small utility to clone all repos of given GitHub user
 # Prerequisites
 Generate [Personal Access Token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
 
+# How to use it
+
+- Download and extract the binary from the releases page
+- `./batch-clone --username <your-github-username> --access-token <your-personal-access-token>`
+
+Please note - if you've never cloned anything from GitHub, you'll be asked to confirm the server fingerprint first. If you don't care (be warned), you can first follow [this advice](https://serverfault.com/a/631149) of more clever people than me on how to trust github's key in the first place.

--- a/batch-clone.go
+++ b/batch-clone.go
@@ -29,7 +29,6 @@ func main() {
 		Name:        "username",
 		Destination: &username,
 	}, &cli.StringFlag{
-		// @todo Add access-token flag as environment variable
 		Name:        "access-token",
 		Destination: &token,
 		EnvVars:     []string{"GITHUB_TOKEN"},
@@ -45,6 +44,10 @@ func main() {
 			},
 			Header: make(http.Header, 0),
 		}
+
+		query := req.URL.Query()
+		query.Add("per_page","1000")
+		req.URL.RawQuery = query.Encode()
 
 		headers := req.Header
 		headers.Add("accept", "application/vnd.github.v3+json")
@@ -72,7 +75,6 @@ func main() {
 		}
 
 		for _, e := range data {
-			// @todo add functionality to actually clone the repositories, instead of only listing them
 			cmd := exec.Command("git", "clone", e.GitURL)
 			fmt.Println(e.GitURL)
 			cmd.Start()


### PR DESCRIPTION
I suspect the problem was due to using default pagination.
I've set now the pagination to 1000 items, which should be enough for most use cases
I might add flag for custom number of items later on